### PR TITLE
fix: pass correct parameter name to get_history_transactions

### DIFF
--- a/src/tools.py
+++ b/src/tools.py
@@ -408,4 +408,4 @@ def fetch_transaction_list(
 ) -> PaginatedResponseHistoryTransactionItem:
     """Fetch superficial information about movements to and from your
     account."""
-    return client.get_history_transactions(cursor=cursor, time=time, limit=limit)
+    return client.get_history_transactions(cursor=cursor, time_from=time, limit=limit)


### PR DESCRIPTION
The fetch_transaction_list tool was passing 'time' as a keyword argument, but the client method expects 'time_from', causing a TypeError at runtime.